### PR TITLE
Feature/non cnn architecture

### DIFF
--- a/main.py
+++ b/main.py
@@ -49,7 +49,7 @@ from utils import (Dcm,
                    tqdm_,
                    dice_coef,
                    save_images)
-
+from vit_seg import TinyViTSeg
 from losses import (CrossEntropy)
 
 datasets_params: dict[str, dict[str, Any]] = {}
@@ -86,7 +86,16 @@ def setup(args) -> tuple[nn.Module, Any, Any, DataLoader, DataLoader, int]:
     K: int = datasets_params[args.dataset]['K']
     kernels: int = datasets_params[args.dataset]['kernels'] if 'kernels' in datasets_params[args.dataset] else 8
     factor: int = datasets_params[args.dataset]['factor'] if 'factor' in datasets_params[args.dataset] else 2
-    net = datasets_params[args.dataset]['net'](1, K, kernels=kernels, factor=factor)
+
+    # select architecture
+    if args.arch == 'vit':
+        net = TinyViTSeg(in_dim=1, out_dim=K,
+                         embed_dim=192, depth=6, heads=6, patch=16, drop=0.0)
+    else:
+        net = datasets_params[args.dataset]['net'](1, K, kernels=kernels, factor=factor)
+
+    net.init_weights()
+    net.to(device)
     net.init_weights()
     net.to(device)
 
@@ -245,6 +254,9 @@ def main():
     parser.add_argument('--debug', action='store_true',
                         help="Keep only a fraction (10 samples) of the datasets, "
                              "to test the logics around epochs and logging easily.")
+    parser.add_argument('--arch', default='enet', choices=['enet', 'vit'],
+                        help="enet (baseline), or vit")
+
 
     args = parser.parse_args()
 

--- a/stitch.py
+++ b/stitch.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3.10
+
+# MIT License
+
+# Copyright (c) 2024 Hoel Kervadec
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import re
+import argparse
+from itertools import repeat
+from pathlib import Path
+from typing import Match, Pattern
+
+import numpy as np
+import nibabel as nib
+from skimage.io import imread
+from skimage.transform import resize
+
+from utils import map_, tqdm_
+
+
+def get_z(image: Path) -> int:
+    return int(image.stem.split('_')[-1])
+
+
+def merge_patient(id_: str, dest_folder: str, images: list[Path],
+                  idxes: list[int], K: int, source_pattern: str) -> None:
+    # print(source_pattern.format(id_=id_))
+    orig_nib = nib.load(source_pattern.format(id_=id_))
+    orig_shape = np.asarray(orig_nib.dataobj).shape
+    # print(orig_nib.affine)
+
+    X, Y, Z = orig_shape
+    assert Z == len(idxes)
+
+    res_arr: np.ndarray = np.zeros((X, Y, Z), dtype=np.int16)
+
+    for idx in idxes:
+        img: Path = images[idx]
+
+        z = get_z(img)
+        img_arr = imread(img)
+        assert img_arr.dtype == np.uint8
+        assert set(np.unique(img_arr)) <= set(range(K))
+
+        resized: np.ndarray = resize(img_arr, (X, Y),
+                                     mode="constant",
+                                     preserve_range=True,
+                                     anti_aliasing=False,
+                                     order=0)
+
+        res_arr[:, :, z] = resized[...]
+
+    assert set(np.unique(res_arr)) <= set(range(K))
+    assert orig_shape == res_arr.shape, (orig_shape, res_arr.shape)
+
+    # res_arr = res_arr.astype(np.int16)
+    res_arr //= 63  # For segthor only
+    assert set(np.unique(res_arr)) == set(range(5)), np.uint8(res_arr)
+
+    new_nib = nib.nifti1.Nifti1Image(res_arr, affine=orig_nib.affine, header=orig_nib.header)
+    nib.save(new_nib, (Path(dest_folder) / id_).with_suffix(".nii.gz"))
+
+
+def main(args) -> None:
+    images: list[Path] = list(Path(args.data_folder).glob("*.png"))
+    grouping_regex: Pattern = re.compile(args.grp_regex)
+
+    stems: list[str] = map_(lambda p: p.stem, images)
+
+    matches: list[Match] = map_(grouping_regex.match, stems)  # type: ignore
+    patients: list[str] = [match.group(1) for match in matches]
+    unique_patients: list[str] = list(set(patients))
+    print(unique_patients)
+    assert len(unique_patients) < len(images)
+    print(f"Found {len(unique_patients)} unique patients out of {len(images)} images ; regex: {args.grp_regex}")
+
+    idx_map: dict[str, list[int]] = dict(zip(unique_patients, repeat(None)))  # type: ignore
+    for i, patient in enumerate(patients):
+        if not idx_map[patient]:
+            idx_map[patient] = []
+
+        idx_map[patient] += [i]
+
+    # print(idx_map)
+    assert sum(len(idx_map[k]) for k in unique_patients) == len(images)
+
+    args.dest_folder.mkdir(parents=True, exist_ok=True)
+
+    for p in tqdm_(unique_patients):
+        merge_patient(p, args.dest_folder, images, idx_map[p], args.num_classes, args.source_scan_pattern)
+    # mmap_(lambda p: merge_patient(p, args.dest_folder, images, idx_map[p], K=args.num_classes), patients)
+
+
+def get_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description='Merging slices parameters')
+    parser.add_argument('--data_folder', type=Path, required=True,
+                        help="The folder containing the images to predict")
+    parser.add_argument('--source_scan_pattern', type=str, required=True,
+                        help="The pattern to get the original scan. This is used to get the correct metadata")
+    parser.add_argument('--dest_folder', type=Path, required=True)
+    parser.add_argument('--grp_regex', type=str, required=True)
+
+    parser.add_argument('--num_classes', type=int, default=4)
+
+    args = parser.parse_args()
+
+    print(args)
+
+    return args
+
+
+if __name__ == "__main__":
+    main(get_args())

--- a/vit_seg.py
+++ b/vit_seg.py
@@ -1,0 +1,119 @@
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+class PatchEmbed(nn.Module):
+    def __init__(self, in_ch: int, embed_dim: int, patch: int = 16):
+        super().__init__()
+        self.proj = nn.Conv2d(in_ch, embed_dim, kernel_size=patch, stride=patch)
+        self.embed_dim = embed_dim
+        self.patch = patch
+    def forward(self, x):
+        x = self.proj(x)                  # [B,D,Hp,Wp]
+        B, D, Hp, Wp = x.shape
+        tokens = x.flatten(2).transpose(1, 2)  # [B, N, D]
+        return tokens, (Hp, Wp)
+
+class MLP(nn.Module):
+    def __init__(self, dim, mlp_ratio=4.0, drop=0.0):
+        super().__init__()
+        hid = int(dim * mlp_ratio)
+        self.fc1 = nn.Linear(dim, hid)
+        self.act = nn.GELU()
+        self.fc2 = nn.Linear(hid, dim)
+        self.drop = nn.Dropout(drop)
+    def forward(self, x):
+        x = self.drop(self.act(self.fc1(x)))
+        x = self.drop(self.fc2(x))
+        return x
+
+class Attention(nn.Module):
+    def __init__(self, dim, heads=6, attn_drop=0.0, proj_drop=0.0):
+        super().__init__()
+        self.h = heads
+        d = dim // heads
+        self.scale = d ** -0.5
+        self.qkv = nn.Linear(dim, dim * 3)
+        self.ad = nn.Dropout(attn_drop)
+        self.proj = nn.Linear(dim, dim)
+        self.pd = nn.Dropout(proj_drop)
+    def forward(self, x):
+        B, N, C = x.shape
+        qkv = self.qkv(x).reshape(B, N, 3, self.h, C // self.h).unbind(2)
+        q, k, v = qkv
+        attn = (q @ k.transpose(-2, -1)) * self.scale
+        attn = self.ad(attn.softmax(dim=-1))
+        x = (attn @ v).transpose(1, 2).reshape(B, N, C)
+        return self.pd(self.proj(x))
+
+class Block(nn.Module):
+    def __init__(self, dim, heads=6, mlp_ratio=4.0, drop=0.0):
+        super().__init__()
+        self.n1 = nn.LayerNorm(dim)
+        self.attn = Attention(dim, heads, drop, drop)
+        self.n2 = nn.LayerNorm(dim)
+        self.mlp = MLP(dim, mlp_ratio, drop)
+    def forward(self, x):
+        x = x + self.attn(self.n1(x))
+        x = x + self.mlp(self.n2(x))
+        return x
+
+def _sincos_pe(Hp, Wp, dim, device):
+    assert dim % 4 == 0
+    y, x = torch.meshgrid(torch.arange(Hp, device=device),
+                          torch.arange(Wp, device=device),
+                          indexing="ij")
+    d = dim // 4
+    omega = 1.0 / (10000 ** (torch.arange(d, device=device) / d))
+    oy = torch.einsum('hw,d->hwd', y.float(), omega)
+    ox = torch.einsum('hw,d->hwd', x.float(), omega)
+    pe = torch.cat([oy.sin(), oy.cos(), ox.sin(), ox.cos()], dim=2)
+    return pe.view(1, Hp*Wp, dim)
+
+class TinyViTSeg(nn.Module):
+    """
+    I/O: [B,C,H,W] -> [B,K,H,W]
+    """
+    def __init__(self, in_dim: int, out_dim: int,
+                 embed_dim: int = 192, depth: int = 6,
+                 heads: int = 6, patch: int = 16, drop: float = 0.0):
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.patch = patch
+        self.embed = PatchEmbed(in_dim, embed_dim, patch)
+        self.drop = nn.Dropout(drop)
+        self.blocks = nn.ModuleList([Block(embed_dim, heads, 4.0, drop) for _ in range(depth)])
+        self.norm = nn.LayerNorm(embed_dim)
+        # decoder: x2 * 3 = x8
+        self.dec1 = nn.ConvTranspose2d(embed_dim, embed_dim//2, 2, 2)
+        self.dec2 = nn.ConvTranspose2d(embed_dim//2, embed_dim//4, 2, 2)
+        self.dec3 = nn.ConvTranspose2d(embed_dim//4, embed_dim//8, 2, 2)
+        self.head = nn.Sequential(
+            nn.Conv2d(embed_dim//8, embed_dim//8, 3, padding=1),
+            nn.GELU(),
+            nn.Conv2d(embed_dim//8, out_dim, 1),
+        )
+        print(f"> Initialized TinyViTSeg(in={in_dim}, out={out_dim}, patch={patch}, "
+              f"embed={embed_dim}, depth={depth}, heads={heads})")
+
+    def forward(self, x):
+        B, C, H, W = x.shape
+        tok, (Hp, Wp) = self.embed(x)               # [B,N,D]
+        tok = tok + _sincos_pe(Hp, Wp, self.embed_dim, tok.device)
+        tok = self.drop(tok)
+        for blk in self.blocks:
+            tok = blk(tok)
+        tok = self.norm(tok)
+        feat = tok.transpose(1, 2).reshape(B, self.embed_dim, Hp, Wp)
+        y = self.dec1(feat); y = self.dec2(y); y = self.dec3(y)
+        if y.shape[-2:] != (H, W):
+            y = F.interpolate(y, size=(H, W), mode='bilinear', align_corners=False)
+        return self.head(y)
+
+    def init_weights(self, *args, **kwargs):
+        for m in self.modules():
+            if isinstance(m, (nn.Conv2d, nn.ConvTranspose2d, nn.Linear)):
+                nn.init.xavier_uniform_(m.weight)
+                if getattr(m, "bias", None) is not None:
+                    nn.init.zeros_(m.bias)


### PR DESCRIPTION
Add vit_seg.py: add TinyViTSeg (ViT-based segmentation)
- Transformer encoder (patch embed + MHA + MLP) with 2D sin/cos PE
- Lightweight decoder: 3× ConvTranspose2d + conv head
- I/O: [B,C,H,W] -> [B,K,H,W], keeps training loop unchanged
- Defaults: embed_dim=192, depth=6, heads=6, patch=16

Modify main.py: add argument "--arch" to choose model. The default remains enet.