### PR TITLE
Feature/different network architecture

### DIFF
--- a/ENet_enhance.py
+++ b/ENet_enhance.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3.10
+# MIT License (same header as your project)
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch import Tensor
+
+# ---------------------- Utils ----------------------
+
+def random_weights_init(m):
+    if isinstance(m, (nn.Conv2d, nn.ConvTranspose2d)):
+        nn.init.xavier_normal_(m.weight.data)
+        if getattr(m, "bias", None) is not None:
+            nn.init.zeros_(m.bias)
+    elif isinstance(m, nn.BatchNorm2d):
+        m.weight.data.normal_(1.0, 0.02)
+        m.bias.data.zero_()
+
+
+def conv_block(in_dim, out_dim, **kwconv):
+    bias = kwconv.pop("bias", False)
+    return nn.Sequential(
+        nn.Conv2d(in_dim, out_dim, bias=bias, **kwconv),
+        nn.BatchNorm2d(out_dim),
+        nn.PReLU()
+    )
+
+
+
+def conv_block_asym(in_dim, out_dim, *, kernel_size: int):
+    pad = (kernel_size - 1) // 2
+    return nn.Sequential(
+        nn.Conv2d(in_dim, out_dim, kernel_size=(kernel_size, 1), padding=(pad, 0), bias=False),
+        nn.Conv2d(out_dim, out_dim, kernel_size=(1, kernel_size), padding=(0, pad), bias=False),
+        nn.BatchNorm2d(out_dim),
+        nn.PReLU()
+    )
+
+
+class SEBlock(nn.Module):
+    def __init__(self, ch: int, r: int = 8):
+        super().__init__()
+        self.avg = nn.AdaptiveAvgPool2d(1)
+        self.fc = nn.Sequential(
+            nn.Conv2d(ch, max(1, ch // r), kernel_size=1, bias=True),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(max(1, ch // r), ch, kernel_size=1, bias=True),
+            nn.Sigmoid(),
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.fc(self.avg(x))
+        return x * w
+
+
+class BoundaryRefine(nn.Module):
+    def __init__(self, ch: int):
+        super().__init__()
+        self.block = nn.Sequential(
+            nn.Conv2d(ch, ch, 3, padding=1, bias=False),
+            nn.BatchNorm2d(ch),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(ch, ch, 3, padding=1, bias=False),
+            nn.BatchNorm2d(ch),
+        )
+        self.act = nn.ReLU(inplace=True)
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.act(x + self.block(x))
+
+
+class AttentionGate(nn.Module):
+    def __init__(self, ch_x: int, ch_g: int):
+        super().__init__()
+        self.theta_x = nn.Conv2d(ch_x, ch_x, kernel_size=1, bias=False)
+        self.phi_g   = nn.Conv2d(ch_g, ch_x, kernel_size=1, bias=False)
+        self.bn      = nn.BatchNorm2d(ch_x)
+        self.act     = nn.ReLU(inplace=True)
+        self.psi     = nn.Conv2d(ch_x, ch_x, kernel_size=1, bias=True)
+        self.sig     = nn.Sigmoid()
+
+    def forward(self, x: Tensor, g: Tensor) -> Tensor:
+        att = self.bn(self.theta_x(x) + self.phi_g(g))
+        att = self.act(att)
+        att = self.sig(self.psi(att))
+        return x * att
+
+
+# ---------------------- Bottlenecks ----------------------
+
+class BottleNeck(nn.Module):
+    def __init__(self, in_dim, out_dim, projectionFactor,
+                 *, dropoutRate=0.01, dilation=1,
+                 asym: bool = False, dilate_last: bool = False,
+                 use_se: bool = True):
+        super().__init__()
+        mid_dim: int = in_dim // projectionFactor
+
+        self.block0 = conv_block(in_dim, mid_dim, kernel_size=1)
+        if not asym:
+            self.block1 = conv_block(mid_dim, mid_dim, kernel_size=3, padding=dilation, dilation=dilation)
+        else:
+            self.block1 = conv_block_asym(mid_dim, mid_dim, kernel_size=5)
+        self.block2 = conv_block(mid_dim, out_dim, kernel_size=1)
+
+        self.se = SEBlock(out_dim) if use_se else nn.Identity()
+        self.do = nn.Dropout(p=dropoutRate)
+        self.PReLU_out = nn.PReLU()
+
+        if in_dim > out_dim:
+            self.conv_out = conv_block(in_dim, out_dim, kernel_size=1)
+        elif dilate_last:
+            self.conv_out = conv_block(in_dim, out_dim, kernel_size=3, padding=1)
+        else:
+            self.conv_out = nn.Identity()
+
+    def forward(self, in_) -> Tensor:
+        b0 = self.block0(in_)
+        b1 = self.block1(b0)
+        b2 = self.block2(b1)
+        do = self.do(b2)
+        do = self.se(do)
+        output = self.PReLU_out(self.conv_out(in_) + do)
+        return output
+
+
+class BottleNeckDownSampling(nn.Module):
+    def __init__(self, in_dim, out_dim, projectionFactor):
+        super().__init__()
+        mid_dim: int = in_dim // projectionFactor
+
+        self.maxpool0 = nn.MaxPool2d(2, return_indices=True)
+        self.block0 = conv_block(in_dim, mid_dim, kernel_size=2, padding=0, stride=2)
+        self.block1 = conv_block(mid_dim, mid_dim, kernel_size=3, padding=1)
+        self.block2 = conv_block(mid_dim, out_dim, kernel_size=1)
+        self.do = nn.Dropout(p=0.01)
+        self.PReLU = nn.PReLU()
+
+    def forward(self, in_) -> tuple[Tensor, Tensor]:
+        maxpool_output, indices = self.maxpool0(in_)
+        b0 = self.block0(in_)
+        b1 = self.block1(b0)
+        b2 = self.block2(b1)
+        do = self.do(b2)
+
+        _, c, _, _ = maxpool_output.shape
+        out = do
+        out[:, :c, :, :] += maxpool_output
+        final_output = self.PReLU(out)
+        return final_output, indices
+
+
+class BottleNeckUpSampling(nn.Module):
+    def __init__(self, in_dim, out_dim, projectionFactor, *, skip_ch: int = None, att_gate: bool = True):
+        super().__init__()
+        mid_dim: int = in_dim // projectionFactor
+        self.unpool = nn.MaxUnpool2d(2)
+        self.att = AttentionGate(ch_x=skip_ch, ch_g=in_dim) if (att_gate and skip_ch is not None) else None
+        concat_ch = in_dim + (skip_ch if skip_ch is not None else 0)
+
+        self.block0 = conv_block(concat_ch, mid_dim, kernel_size=3, padding=1)
+        self.block1 = conv_block(mid_dim, mid_dim, kernel_size=3, padding=1)
+        self.block2 = conv_block(mid_dim, out_dim, kernel_size=1)
+        self.do = nn.Dropout(p=0.01)
+        self.PReLU = nn.PReLU()
+
+    def forward(self, args) -> Tensor:
+        in_, indices, skip = args
+        up = self.unpool(in_, indices)
+        if self.att is not None:
+            skip = self.att(skip, up)
+        b0 = self.block0(torch.cat((up, skip), dim=1))
+        b1 = self.block1(b0)
+        b2 = self.block2(b1)
+        do = self.do(b2)
+        output = self.PReLU(up + do)
+        return output
+
+
+# ---------------------- ENet_enhance ----------------------
+
+class ENet_enhance(nn.Module):
+    """
+    Enhanced ENet: SE + Lightweight Attention Gating + Dual-Head Supervision + Boundary Refinement
+    API aligned with original ENet: ENet_enhance(input_dim, output_dim, number_of_convolutional_kernels,
+    scaling_factor, use_SE=True, return_auxiliary_output=True)
+    """
+    def __init__(self, in_dim: int, out_dim: int, **kwargs):
+        super().__init__()
+        Fp: int = kwargs.get("factor", 4)
+        K:  int = kwargs.get("kernels", 16)
+        use_se: bool = kwargs.get("use_se", True)
+        self.return_aux: bool = kwargs.get("return_aux", True)
+
+        # Initial
+        self.conv0 = nn.Conv2d(in_dim, K - 1, kernel_size=3, stride=2, padding=1, bias=False)
+        self.maxpool0 = nn.MaxPool2d(2, return_indices=False, ceil_mode=False)
+
+        # Down
+        self.bottleneck1_0 = BottleNeckDownSampling(K, K * 4, Fp)
+        self.bottleneck1_1 = nn.Sequential(
+            BottleNeck(K * 4, K * 4, Fp, use_se=use_se),
+            BottleNeck(K * 4, K * 4, Fp, use_se=use_se),
+            BottleNeck(K * 4, K * 4, Fp, use_se=use_se),
+            BottleNeck(K * 4, K * 4, Fp, use_se=use_se),
+        )
+        self.bottleneck2_0 = BottleNeckDownSampling(K * 4, K * 8, Fp)
+        self.bottleneck2_1 = nn.Sequential(
+            BottleNeck(K * 8, K * 8, Fp, dropoutRate=0.1, use_se=use_se),
+            BottleNeck(K * 8, K * 8, Fp, dilation=2, use_se=use_se),
+            BottleNeck(K * 8, K * 8, Fp, dropoutRate=0.1, asym=True, use_se=use_se),
+            BottleNeck(K * 8, K * 8, Fp, dilation=4, use_se=use_se),
+            BottleNeck(K * 8, K * 8, Fp, dropoutRate=0.1, use_se=use_se),
+            BottleNeck(K * 8, K * 8, Fp, dilation=8, use_se=use_se),
+            BottleNeck(K * 8, K * 8, Fp, dropoutRate=0.1, asym=True, use_se=use_se),
+            BottleNeck(K * 8, K * 8, Fp, dilation=16, use_se=use_se),
+        )
+
+        # Middle
+        self.bottleneck3 = nn.Sequential(
+            BottleNeck(K * 8, K * 8, Fp, dropoutRate=0.1, use_se=use_se),
+            BottleNeck(K * 8, K * 8, Fp, dilation=2, use_se=use_se),
+            BottleNeck(K * 8, K * 8, Fp, dropoutRate=0.1, asym=True, use_se=use_se),
+            BottleNeck(K * 8, K * 8, Fp, dilation=4, use_se=use_se),
+            BottleNeck(K * 8, K * 8, Fp, dropoutRate=0.1, use_se=use_se),
+            BottleNeck(K * 8, K * 8, Fp, dilation=8, use_se=use_se),
+            BottleNeck(K * 8, K * 8, Fp, dropoutRate=0.1, asym=True, use_se=use_se),
+            BottleNeck(K * 8, K * 4, Fp, dilation=16, dilate_last=True, use_se=use_se),
+        )
+
+        # Up (skip with AttentionGate)
+        # bn3_out has K*4 channels, so in_dim=K*4; skip is bn1_out (K*4)
+        self.bottleneck4 = nn.Sequential(
+            BottleNeckUpSampling(K * 4, K * 4, Fp, skip_ch=K * 4, att_gate=True),  # ✅
+            BottleNeck(K * 4, K * 4, Fp, dropoutRate=0.1, use_se=use_se),
+            BottleNeck(K * 4, K, Fp, dropoutRate=0.1, use_se=use_se),
+        )
+        # The channel of bn4_out is K, so in_dim=K; skip is outputInitial(K).
+        self.bottleneck5 = nn.Sequential(
+            BottleNeckUpSampling(K, K, Fp, skip_ch=K, att_gate=True),  # ✅
+            BottleNeck(K, K, Fp, dropoutRate=0.1, use_se=use_se),
+        )
+
+        # Deep supervision heads
+        self.ds_head4 = nn.Conv2d(K,     out_dim, kernel_size=1)  # after bottleneck4 (H/4)
+        self.ds_head3 = nn.Conv2d(K * 4, out_dim, kernel_size=1)  # after bottleneck3 (H/8)
+
+        # Final refine & head
+        self.br = BoundaryRefine(K)
+        self.final = nn.Sequential(
+            conv_block(K, K, kernel_size=3, padding=1, bias=False, stride=1),
+            conv_block(K, K, kernel_size=3, padding=1, bias=False, stride=1),
+            nn.Conv2d(K, out_dim, kernel_size=1)
+        )
+
+        print(f"> Initialized ENet_enhance ({in_dim=}->{out_dim=}) with factor={Fp}, kernels={K}, return_aux={self.return_aux}")
+
+    def forward(self, input, return_aux: bool = None):
+        if return_aux is None:
+            return_aux = self.return_aux
+
+        # Initial
+        conv_0 = self.conv0(input)
+        maxpool_0 = self.maxpool0(input)
+        outputInitial = torch.cat((conv_0, maxpool_0), dim=1)  # [B, K, H/2, W/2]
+
+        # Down
+        bn1_0, indices_1 = self.bottleneck1_0(outputInitial)      # -> [B, 4K, H/4, W/4]
+        bn1_out = self.bottleneck1_1(bn1_0)                       # skip1
+        bn2_0, indices_2 = self.bottleneck2_0(bn1_out)            # -> [B, 8K, H/8, W/8]
+        bn2_out = self.bottleneck2_1(bn2_0)
+
+        # Middle
+        bn3_out = self.bottleneck3(bn2_out)                       # -> [B, 4K, H/8, W/8]
+
+        # Up
+        bn4_out = self.bottleneck4((bn3_out, indices_2, bn1_out))         # -> [B, K, H/4, W/4]
+        bn5_out = self.bottleneck5((bn4_out, indices_1, outputInitial))   # -> [B, K, H/2, W/2]
+
+        # DS logits(Upsampling to H, W))
+        aux4 = F.interpolate(self.ds_head4(bn4_out), scale_factor=4, mode="bilinear", align_corners=False)
+        aux3 = F.interpolate(self.ds_head3(bn3_out), scale_factor=8, mode="bilinear", align_corners=False)
+
+        # Final
+        interpolated = F.interpolate(bn5_out, mode='nearest', scale_factor=2)  # -> [B, K, H, W]
+        refined = self.br(interpolated)
+        logits = self.final(refined)                                           # -> [B, out_dim, H, W]
+
+        if return_aux:
+            return logits, aux4, aux3
+        return logits
+
+    def init_weights(self, *args, **kwargs):
+        self.apply(random_weights_init)

--- a/main.py
+++ b/main.py
@@ -42,6 +42,7 @@ from functools import partial
 from dataset import SliceDataset
 from ShallowNet import shallowCNN
 from ENet import ENet
+from ENet_enhance import ENet_enhance
 from utils import (Dcm,
                    class2one_hot,
                    probs2one_hot,
@@ -86,7 +87,14 @@ def setup(args) -> tuple[nn.Module, Any, Any, DataLoader, DataLoader, int]:
     K: int = datasets_params[args.dataset]['K']
     kernels: int = datasets_params[args.dataset]['kernels'] if 'kernels' in datasets_params[args.dataset] else 8
     factor: int = datasets_params[args.dataset]['factor'] if 'factor' in datasets_params[args.dataset] else 2
-    net = datasets_params[args.dataset]['net'](1, K, kernels=kernels, factor=factor)
+
+    if args.arch == 'enetx':
+        net = ENet_enhance(in_dim=1, out_dim=K,
+                           kernels=datasets_params[args.dataset].get('kernels', 8),
+                           factor=datasets_params[args.dataset].get('factor', 2),
+                           use_se=True, return_aux=True)
+    else:
+        net = datasets_params[args.dataset]['net'](1, K, kernels=kernels, factor=factor)
     net.init_weights()
     net.to(device)
 
@@ -177,7 +185,13 @@ def runTraining(args):
                     assert 0 <= img.min() and img.max() <= 1
                     B, _, W, H = img.shape
 
-                    pred_logits = net(img)
+                    # ==== forward (compatible with main output + two auxiliary heads) ====
+                    out = net(img)  # If it is ENet_enhance, out will be (logits, aux4, aux3)
+                    if isinstance(out, tuple):
+                        pred_logits, aux4, aux3 = out
+                    else:
+                        pred_logits, aux4, aux3 = out, None, None
+
                     pred_probs = F.softmax(1 * pred_logits, dim=1)  # 1 is the temperature parameter
 
                     # Metrics computation, not used for training
@@ -185,6 +199,13 @@ def runTraining(args):
                     log_dice[e, j:j + B, :] = dice_coef(pred_seg, gt)  # One DSC value per sample and per class
 
                     loss = loss_fn(pred_probs, gt)
+                    if aux4 is not None:
+                        aux4_probs = F.softmax(aux4, dim=1)
+                        loss = loss + 0.3 * loss_fn(aux4_probs, gt)
+
+                    if aux3 is not None:
+                        aux3_probs = F.softmax(aux3, dim=1)
+                        loss = loss + 0.2 * loss_fn(aux3_probs, gt)
                     log_loss[e, i] = loss.item()  # One loss value per batch (averaged in the loss)
 
                     if opt:  # Only for training
@@ -245,6 +266,8 @@ def main():
     parser.add_argument('--debug', action='store_true',
                         help="Keep only a fraction (10 samples) of the datasets, "
                              "to test the logics around epochs and logging easily.")
+    parser.add_argument('--arch', default='enet', choices=['enet', 'enetx'],
+                        help="enet (baseline), enetx (ENet_enhance)")
 
     args = parser.parse_args()
 

--- a/stitch.py
+++ b/stitch.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3.10
+
+# MIT License
+
+# Copyright (c) 2024 Hoel Kervadec
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import re
+import argparse
+from itertools import repeat
+from pathlib import Path
+from typing import Match, Pattern
+
+import numpy as np
+import nibabel as nib
+from skimage.io import imread
+from skimage.transform import resize
+
+from utils import map_, tqdm_
+
+
+def get_z(image: Path) -> int:
+    return int(image.stem.split('_')[-1])
+
+
+def merge_patient(id_: str, dest_folder: str, images: list[Path],
+                  idxes: list[int], K: int, source_pattern: str) -> None:
+    # print(source_pattern.format(id_=id_))
+    orig_nib = nib.load(source_pattern.format(id_=id_))
+    orig_shape = np.asarray(orig_nib.dataobj).shape
+    # print(orig_nib.affine)
+
+    X, Y, Z = orig_shape
+    assert Z == len(idxes)
+
+    res_arr: np.ndarray = np.zeros((X, Y, Z), dtype=np.int16)
+
+    for idx in idxes:
+        img: Path = images[idx]
+
+        z = get_z(img)
+        img_arr = imread(img)
+        assert img_arr.dtype == np.uint8
+        assert set(np.unique(img_arr)) <= set(range(K))
+
+        resized: np.ndarray = resize(img_arr, (X, Y),
+                                     mode="constant",
+                                     preserve_range=True,
+                                     anti_aliasing=False,
+                                     order=0)
+
+        res_arr[:, :, z] = resized[...]
+
+    assert set(np.unique(res_arr)) <= set(range(K))
+    assert orig_shape == res_arr.shape, (orig_shape, res_arr.shape)
+
+    # res_arr = res_arr.astype(np.int16)
+    res_arr //= 63  # For segthor only
+    assert set(np.unique(res_arr)) == set(range(5)), np.uint8(res_arr)
+
+    new_nib = nib.nifti1.Nifti1Image(res_arr, affine=orig_nib.affine, header=orig_nib.header)
+    nib.save(new_nib, (Path(dest_folder) / id_).with_suffix(".nii.gz"))
+
+
+def main(args) -> None:
+    images: list[Path] = list(Path(args.data_folder).glob("*.png"))
+    grouping_regex: Pattern = re.compile(args.grp_regex)
+
+    stems: list[str] = map_(lambda p: p.stem, images)
+
+    matches: list[Match] = map_(grouping_regex.match, stems)  # type: ignore
+    patients: list[str] = [match.group(1) for match in matches]
+    unique_patients: list[str] = list(set(patients))
+    print(unique_patients)
+    assert len(unique_patients) < len(images)
+    print(f"Found {len(unique_patients)} unique patients out of {len(images)} images ; regex: {args.grp_regex}")
+
+    idx_map: dict[str, list[int]] = dict(zip(unique_patients, repeat(None)))  # type: ignore
+    for i, patient in enumerate(patients):
+        if not idx_map[patient]:
+            idx_map[patient] = []
+
+        idx_map[patient] += [i]
+
+    # print(idx_map)
+    assert sum(len(idx_map[k]) for k in unique_patients) == len(images)
+
+    args.dest_folder.mkdir(parents=True, exist_ok=True)
+
+    for p in tqdm_(unique_patients):
+        merge_patient(p, args.dest_folder, images, idx_map[p], args.num_classes, args.source_scan_pattern)
+    # mmap_(lambda p: merge_patient(p, args.dest_folder, images, idx_map[p], K=args.num_classes), patients)
+
+
+def get_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description='Merging slices parameters')
+    parser.add_argument('--data_folder', type=Path, required=True,
+                        help="The folder containing the images to predict")
+    parser.add_argument('--source_scan_pattern', type=str, required=True,
+                        help="The pattern to get the original scan. This is used to get the correct metadata")
+    parser.add_argument('--dest_folder', type=Path, required=True)
+    parser.add_argument('--grp_regex', type=str, required=True)
+
+    parser.add_argument('--num_classes', type=int, default=4)
+
+    args = parser.parse_args()
+
+    print(args)
+
+    return args
+
+
+if __name__ == "__main__":
+    main(get_args())


### PR DESCRIPTION
Add ENet_enhance.py:
- ENet-based CNN for segmentation with SE blocks & BoundaryRefine
- Adds AttentionGate on skip connections; dual aux heads for deep supervision
- API: ENet_enhance(in_dim, out_dim, kernels=K, factor=Fp, use_se=True, return_aux=True)
- Output: logits [B,out_dim,H,W] (+ aux4, aux3 when return_aux=True)
- Xavier init for Conv/Deconv; BN/PReLU blocks; asymmetric/dilated bottlenecks

Modify main.py: add argument "--arch" to choose model. The default remains enet